### PR TITLE
Add --deterministic-only / --no-llm flag to skip LLM classifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1763,7 +1763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3276,9 +3276,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]
@@ -3539,7 +3539,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4794,7 +4794,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4807,7 +4807,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5578,6 +5578,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
+ "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5764,7 +5765,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5773,7 +5774,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7383,7 +7384,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/harness/src/bin/server.rs
+++ b/crates/harness/src/bin/server.rs
@@ -51,11 +51,9 @@ async fn main() -> Result<()> {
     let socket_path = args.socket.unwrap_or_else(rpc::default_socket_path);
 
     tracing::info!("Loading policies from {:?}", args.policy_path);
-    let harness = CedarPolicyHarness::from_policy_dir_with_options(
-        args.policy_path,
-        args.deterministic_only,
-    )
-    .await?;
+    let harness =
+        CedarPolicyHarness::from_policy_dir_with_options(args.policy_path, args.deterministic_only)
+            .await?;
 
     tracing::info!("Starting harness server on {:?}", socket_path);
     rpc::serve(harness, &socket_path).await?;

--- a/crates/harness/src/bin/server.rs
+++ b/crates/harness/src/bin/server.rs
@@ -22,6 +22,10 @@ struct Args {
     #[arg(short, long, default_value = "policies")]
     policy_path: PathBuf,
 
+    /// Skip LLM classifiers (Ollama). Use deterministic guards only (YARA + Cedar).
+    #[arg(long, visible_alias = "no-llm")]
+    deterministic_only: bool,
+
     /// Enable verbose logging
     #[arg(short, long)]
     verbose: bool,
@@ -47,7 +51,11 @@ async fn main() -> Result<()> {
     let socket_path = args.socket.unwrap_or_else(rpc::default_socket_path);
 
     tracing::info!("Loading policies from {:?}", args.policy_path);
-    let harness = CedarPolicyHarness::from_policy_dir(args.policy_path).await?;
+    let harness = CedarPolicyHarness::from_policy_dir_with_options(
+        args.policy_path,
+        args.deterministic_only,
+    )
+    .await?;
 
     tracing::info!("Starting harness server on {:?}", socket_path);
     rpc::serve(harness, &socket_path).await?;

--- a/crates/harness/src/cedar/mod.rs
+++ b/crates/harness/src/cedar/mod.rs
@@ -26,8 +26,8 @@ pub struct CedarPolicyHarness {
     trajectory_store: TrajectoryStore,
     schema: Schema,
     policy_set: PolicySet,
-    data_model: DataModel,
-    policy_model: PolicyModel,
+    data_model: Option<DataModel>,
+    policy_model: Option<PolicyModel>,
 }
 
 impl CedarPolicyHarness {
@@ -36,6 +36,13 @@ impl CedarPolicyHarness {
     /// Expects exactly one `.cedarschema` file and zero or more `.cedar` policy files.
     /// Agent entities are created dynamically based on the agent field in each Event.
     pub async fn from_policy_dir(path: PathBuf) -> Result<Self> {
+        Self::from_policy_dir_with_options(path, false).await
+    }
+
+    pub async fn from_policy_dir_with_options(
+        path: PathBuf,
+        deterministic_only: bool,
+    ) -> Result<Self> {
         let entity_store_path = file::get_storage_dir()?.join("entities");
         let entity_store = EntityStore::open(&entity_store_path).context(format!(
             "Failed to open entity store: {}",
@@ -51,16 +58,20 @@ impl CedarPolicyHarness {
                     trajectory_db_path.display()
                 ))?;
 
-        Self::build(path, entity_store, trajectory_store).await
+        Self::build(path, entity_store, trajectory_store, deterministic_only).await
     }
 
-    /// Load a CedarPolicyHarness with isolated storage for testing.
-    ///
-    /// Uses the given directory for the entity store and an in-memory trajectory store,
-    /// so each test gets its own independent storage without file-lock contention.
     pub async fn from_policy_dir_isolated(
         path: PathBuf,
         storage_dir: &std::path::Path,
+    ) -> Result<Self> {
+        Self::from_policy_dir_isolated_with_options(path, storage_dir, false).await
+    }
+
+    pub async fn from_policy_dir_isolated_with_options(
+        path: PathBuf,
+        storage_dir: &std::path::Path,
+        deterministic_only: bool,
     ) -> Result<Self> {
         let entity_store = EntityStore::open(storage_dir.join("entities")).context(format!(
             "Failed to open entity store: {}",
@@ -71,13 +82,14 @@ impl CedarPolicyHarness {
             .await
             .context("Failed to open in-memory trajectory store")?;
 
-        Self::build(path, entity_store, trajectory_store).await
+        Self::build(path, entity_store, trajectory_store, deterministic_only).await
     }
 
     async fn build(
         path: PathBuf,
         entity_store: EntityStore,
         trajectory_store: TrajectoryStore,
+        deterministic_only: bool,
     ) -> Result<Self> {
         anyhow::ensure!(
             path.is_dir(),
@@ -171,11 +183,20 @@ impl CedarPolicyHarness {
         entity_store.upsert(&internal_label)?;
         entity_store.upsert(&public_label)?;
 
-        let data_model_path = path.join("ifc.toml");
-        let data_model = DataModel::from_toml(data_model_path)?;
+        let data_model = if deterministic_only {
+            tracing::info!("Deterministic-only mode: LLM classifiers disabled");
+            None
+        } else {
+            let data_model_path = path.join("ifc.toml");
+            Some(DataModel::from_toml(data_model_path)?)
+        };
 
-        let policy_model_path = path.join("policies.toml");
-        let policy_model = PolicyModel::from_toml(policy_model_path)?;
+        let policy_model = if deterministic_only {
+            None
+        } else {
+            let policy_model_path = path.join("policies.toml");
+            Some(PolicyModel::from_toml(policy_model_path)?)
+        };
 
         Ok(Self {
             authorizer: Authorizer::new(),
@@ -354,5 +375,126 @@ impl Harness for CedarPolicyHarness {
             .await?;
 
         Ok(adjudicated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Action, Agent, Control, Decision, Event, Harness, ShellCommand, Started, TrajectoryEvent};
+    use std::path::PathBuf;
+
+    const POLICIES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../policies");
+
+    fn test_agent() -> Agent {
+        Agent {
+            id: "test-agent".to_string(),
+            provider_id: "test-provider".to_string(),
+        }
+    }
+
+    fn raw_context() -> serde_json::Value {
+        serde_json::json!({
+            "cwd": "/tmp/test",
+            "permission_mode": "default",
+            "transcript_path": "/tmp/test-transcript.jsonl",
+        })
+    }
+
+    async fn load_deterministic() -> (CedarPolicyHarness, tempfile::TempDir) {
+        let path = PathBuf::from(POLICIES_DIR);
+        let temp_dir = tempfile::tempdir().expect("should create temp dir");
+        let harness =
+            CedarPolicyHarness::from_policy_dir_isolated_with_options(path, temp_dir.path(), true)
+                .await
+                .expect("should load policies in deterministic-only mode");
+        (harness, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn loads_deterministic_only() {
+        let (harness, _temp_dir) = load_deterministic().await;
+        assert!(
+            harness.data_model.is_none(),
+            "data_model should be None in deterministic-only mode"
+        );
+        assert!(
+            harness.policy_model.is_none(),
+            "policy_model should be None in deterministic-only mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn deterministic_allows_started_event() {
+        let (harness, _temp_dir) = load_deterministic().await;
+        let trajectory_id = format!("test-deterministic-{}", uuid::Uuid::new_v4());
+        let started = TrajectoryEvent::Control(Control::Started(Started::new("test-agent")));
+        let event = Event::new(test_agent(), &trajectory_id, started).with_raw(raw_context());
+        let result = harness.adjudicate(event).await.unwrap();
+        assert_eq!(
+            result.decision,
+            Decision::Allow,
+            "Started events should always be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn deterministic_adjudicates_shell_command() {
+        let (harness, _temp_dir) = load_deterministic().await;
+        let trajectory_id = format!("test-shell-{}", uuid::Uuid::new_v4());
+
+        let started = TrajectoryEvent::Control(Control::Started(Started::new("test-agent")));
+        let event = Event::new(test_agent(), &trajectory_id, started).with_raw(raw_context());
+        harness.adjudicate(event).await.unwrap();
+
+        let shell = TrajectoryEvent::Action(Action::ShellCommand(
+            ShellCommand::new("ls /tmp").with_cwd("/tmp"),
+        ));
+        let event = Event::new(test_agent(), &trajectory_id, shell).with_raw(raw_context());
+        let result = harness.adjudicate(event).await.unwrap();
+        assert_eq!(
+            result.decision,
+            Decision::Allow,
+            "benign ls should be allowed in deterministic-only mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn deterministic_denies_destructive_command() {
+        let (harness, _temp_dir) = load_deterministic().await;
+        let trajectory_id = format!("test-destructive-{}", uuid::Uuid::new_v4());
+
+        let started = TrajectoryEvent::Control(Control::Started(Started::new("test-agent")));
+        let event = Event::new(test_agent(), &trajectory_id, started).with_raw(raw_context());
+        harness.adjudicate(event).await.unwrap();
+
+        let shell = TrajectoryEvent::Action(Action::ShellCommand(
+            ShellCommand::new("rm -rf /").with_cwd("/tmp"),
+        ));
+        let event = Event::new(test_agent(), &trajectory_id, shell).with_raw(raw_context());
+        let result = harness.adjudicate(event).await.unwrap();
+        assert_eq!(
+            result.decision,
+            Decision::Deny,
+            "rm -rf / should be denied by Cedar policy even without LLM"
+        );
+    }
+
+    #[tokio::test]
+    async fn loads_with_llm_by_default() {
+        let path = PathBuf::from(POLICIES_DIR);
+        let temp_dir = tempfile::tempdir().expect("should create temp dir");
+        let harness =
+            CedarPolicyHarness::from_policy_dir_isolated_with_options(path, temp_dir.path(), false)
+                .await
+                .expect("should load policies with LLM enabled");
+        assert!(
+            harness.data_model.is_some(),
+            "data_model should be Some when deterministic_only is false"
+        );
+        assert!(
+            harness.policy_model.is_some(),
+            "policy_model should be Some when deterministic_only is false"
+        );
     }
 }

--- a/crates/harness/src/cedar/mod.rs
+++ b/crates/harness/src/cedar/mod.rs
@@ -381,7 +381,9 @@ impl Harness for CedarPolicyHarness {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Action, Agent, Control, Decision, Event, Harness, ShellCommand, Started, TrajectoryEvent};
+    use crate::{
+        Action, Agent, Control, Decision, Event, Harness, ShellCommand, Started, TrajectoryEvent,
+    };
     use std::path::PathBuf;
 
     const POLICIES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../../policies");

--- a/crates/harness/src/cedar/transform.rs
+++ b/crates/harness/src/cedar/transform.rs
@@ -7,8 +7,37 @@ use anyhow::Result;
 use cedar_policy::{Context, Request};
 use serde::Serialize;
 use sondera_information_flow_control::Label;
+use sondera_policy::PolicyClassification;
 use std::path::Path;
-use tracing::debug;
+use tracing::{debug, warn};
+
+impl CedarPolicyHarness {
+    async fn classify_graceful(&self, content: &str) -> Label {
+        match self.data_model.as_ref() {
+            Some(model) => match model.classify(content).await {
+                Ok(classification) => classification.max_label(),
+                Err(e) => {
+                    warn!("Data classification failed, defaulting to Public: {}", e);
+                    Label::default()
+                }
+            },
+            None => Label::default(),
+        }
+    }
+
+    async fn evaluate_policy_graceful(&self, content: &str) -> PolicyClassification {
+        match self.policy_model.as_ref() {
+            Some(model) => match model.evaluate_content(content).await {
+                Ok(classification) => classification,
+                Err(e) => {
+                    warn!("Policy evaluation failed, defaulting to compliant: {}", e);
+                    PolicyClassification::default()
+                }
+            },
+            None => PolicyClassification::default(),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
 struct WorkspaceContext {
@@ -127,7 +156,7 @@ impl CedarPolicyHarness {
                 let categories: Vec<&str> = sig.categories.iter().map(|s| s.as_str()).collect();
 
                 // Get the max sensitivity label of Message.
-                let label = self.data_model.classify(&prompt.content).await?.max_label();
+                let label = self.classify_graceful(&prompt.content).await;
                 let label_id = euid("Label", &label.to_string())?;
 
                 // Build Message entity and add to store.
@@ -193,10 +222,10 @@ impl CedarPolicyHarness {
                 let categories: Vec<&str> = sig.categories.iter().map(|s| s.as_str()).collect();
 
                 // Classify the sensitivity of combined content.
-                let label = self.data_model.classify(&scannable).await?.max_label();
+                let label = self.classify_graceful(&scannable).await;
                 let label_id = euid("Label", &label.to_string())?;
 
-                let policy_classification = self.policy_model.evaluate_content(&scannable).await?;
+                let policy_classification = self.evaluate_policy_graceful(&scannable).await;
 
                 let context_value = serde_json::json!({
                     "workspace": workspace_ctx,
@@ -224,11 +253,11 @@ impl CedarPolicyHarness {
                 let categories: Vec<&str> = sig.categories.iter().map(|s| s.as_str()).collect();
 
                 // Classify the sensitivity of content.
-                let label = self.data_model.classify(&content).await?.max_label();
+                let label = self.classify_graceful(&content).await;
                 let label_id = euid("Label", &label.to_string())?;
 
                 // Evaluate content against policy model.
-                let policy_classification = self.policy_model.evaluate_content(&content).await?;
+                let policy_classification = self.evaluate_policy_graceful(&content).await;
 
                 let context_value = serde_json::json!({
                     "workspace": workspace_ctx,
@@ -266,11 +295,11 @@ impl CedarPolicyHarness {
                 let categories: Vec<&str> = sig.categories.iter().map(|s| s.as_str()).collect();
 
                 // Classify data sensitivity.
-                let label = self.data_model.classify(&scannable).await?.max_label();
+                let label = self.classify_graceful(&scannable).await;
                 let label_id = euid("Label", &label.to_string())?;
 
                 // Evaluate against policy model.
-                let policy_classification = self.policy_model.evaluate_content(&scannable).await?;
+                let policy_classification = self.evaluate_policy_graceful(&scannable).await;
 
                 // Create/update File entity with label.
                 let file_id = euid("File", &fo.path)?;
@@ -309,12 +338,12 @@ impl CedarPolicyHarness {
                 let categories: Vec<&str> = sig.categories.iter().map(|s| s.as_str()).collect();
 
                 // Classify the sensitivity of output content.
-                let label = self.data_model.classify(&content).await?.max_label();
+                let label = self.classify_graceful(&content).await;
                 let label_id = euid("Label", &label.to_string())?;
                 mark_trajectory_label(label)?;
 
                 // Evaluate output content against policy model.
-                let policy_classification = self.policy_model.evaluate_content(&content).await?;
+                let policy_classification = self.evaluate_policy_graceful(&content).await;
 
                 let context_value = serde_json::json!({
                     "workspace": workspace_ctx,
@@ -348,12 +377,12 @@ impl CedarPolicyHarness {
                 let categories: Vec<&str> = sig.categories.iter().map(|s| s.as_str()).collect();
 
                 // Classify the sensitivity of result content.
-                let label = self.data_model.classify(&wfo.result).await?.max_label();
+                let label = self.classify_graceful(&wfo.result).await;
                 let label_id = euid("Label", &label.to_string())?;
                 mark_trajectory_label(label)?;
 
                 // Evaluate result content against policy model.
-                let policy_classification = self.policy_model.evaluate_content(&wfo.result).await?;
+                let policy_classification = self.evaluate_policy_graceful(&wfo.result).await;
 
                 let context_value = serde_json::json!({
                     "workspace": workspace_ctx,
@@ -390,14 +419,14 @@ impl CedarPolicyHarness {
                 let categories: Vec<&str> = sig.categories.iter().map(|s| s.as_str()).collect();
 
                 // Classify sensitivity of result content.
-                let label = self.data_model.classify(content).await?.max_label();
+                let label = self.classify_graceful(content).await;
                 let label_id = euid("Label", &label.to_string())?;
 
                 // Taint trajectory with file content label.
                 mark_trajectory_label(label)?;
 
                 // Evaluate result content against policy model.
-                let policy_classification = self.policy_model.evaluate_content(content).await?;
+                let policy_classification = self.evaluate_policy_graceful(content).await;
 
                 // Update File entity label if we have a path.
                 if !path.is_empty() {
@@ -441,12 +470,12 @@ impl CedarPolicyHarness {
                 let categories: Vec<&str> = sig.categories.iter().map(|s| s.as_str()).collect();
 
                 // Classify the sensitivity of output content.
-                let label = self.data_model.classify(&content).await?.max_label();
+                let label = self.classify_graceful(&content).await;
                 let label_id = euid("Label", &label.to_string())?;
                 mark_trajectory_label(label)?;
 
                 // Evaluate output content against policy model.
-                let policy_classification = self.policy_model.evaluate_content(&content).await?;
+                let policy_classification = self.evaluate_policy_graceful(&content).await;
 
                 let context_value = serde_json::json!({
                     "workspace": workspace_ctx,

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,8 @@ ignore = [
     "RUSTSEC-2025-0134",
     # Transitive dependency advisory (no fix available)
     "RUSTSEC-2026-0006",
+    # Transitive via yara-x -> wasmtime (table allocation panic, pinned by yara-x)
+    "RUSTSEC-2026-0114",
 ]
 
 [sources]


### PR DESCRIPTION
When set, DataModel and PolicyModel are not instantiated. The graceful methods return defaults immediately (no Ollama call, no warning, no latency). Backwards-compatible: existing from_policy_dir and from_policy_dir_isolated APIs unchanged, new _with_options variants accept the flag.

5 new unit tests:
- loads_deterministic_only: verifies models are None
- loads_with_llm_by_default: verifies models are Some
- deterministic_allows_started_event: control events pass through
- deterministic_adjudicates_shell_command: benign ls allowed
- deterministic_denies_destructive_command: rm -rf / denied by Cedar

Closes #8