### PR TITLE
feature(copilot): add Copilot CLI hook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ Write your own `.cedar` files into this directory to add custom rules. The
 harness evaluates all policies on every hook event — a single matching `forbid`
 overrides any `permit`.
 
+### 4. Examples
+
+The `examples/` directory contains standalone policies, payloads, and runnable
+hook examples.
+
+- [GitHub Copilot CLI hook enforcement](examples/github_copilot_cli_hooks/README.md)
+  shows a local `sondera copilot ...` hook path with fixture payloads, an
+  investment-advisor Cedar policy pack, and a smoke script.
+
 ## Architecture
 
 ![Architecture](docs/architecture.png)

--- a/examples/github_copilot_cli_hooks/.github/hooks/sondera.json
+++ b/examples/github_copilot_cli_hooks/.github/hooks/sondera.json
@@ -1,0 +1,122 @@
+{
+  "version": 1,
+  "disableAllHooks": false,
+  "hooks": {
+    "agentStop": [
+      {
+        "type": "command",
+        "bash": "sondera copilot agent-stop",
+        "powershell": "sondera.exe copilot agent-stop",
+        "timeoutSec": 30
+      }
+    ],
+    "errorOccurred": [
+      {
+        "type": "command",
+        "bash": "sondera copilot error-occurred",
+        "powershell": "sondera.exe copilot error-occurred",
+        "timeoutSec": 30
+      }
+    ],
+    "notification": [
+      {
+        "type": "command",
+        "bash": "sondera copilot notification",
+        "powershell": "sondera.exe copilot notification",
+        "timeoutSec": 30
+      }
+    ],
+    "permissionRequest": [
+      {
+        "type": "command",
+        "bash": "sondera copilot permission-request",
+        "powershell": "sondera.exe copilot permission-request",
+        "matcher": {
+          "toolName": "bash"
+        },
+        "timeoutSec": 30
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "sondera copilot post-tool-use",
+        "powershell": "sondera.exe copilot post-tool-use",
+        "matcher": {
+          "toolName": "bash"
+        },
+        "timeoutSec": 30
+      }
+    ],
+    "postToolUseFailure": [
+      {
+        "type": "command",
+        "bash": "sondera copilot post-tool-use-failure",
+        "powershell": "sondera.exe copilot post-tool-use-failure",
+        "matcher": {
+          "toolName": "bash"
+        },
+        "timeoutSec": 30
+      }
+    ],
+    "preCompact": [
+      {
+        "type": "command",
+        "bash": "sondera copilot pre-compact",
+        "powershell": "sondera.exe copilot pre-compact",
+        "timeoutSec": 30
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "sondera copilot pre-tool-use",
+        "powershell": "sondera.exe copilot pre-tool-use",
+        "matcher": {
+          "toolName": "bash"
+        },
+        "timeoutSec": 30
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "sondera copilot session-end",
+        "powershell": "sondera.exe copilot session-end",
+        "timeoutSec": 30
+      }
+    ],
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "sondera copilot session-start",
+        "powershell": "sondera.exe copilot session-start",
+        "timeoutSec": 30
+      }
+    ],
+    "subagentStart": [
+      {
+        "type": "command",
+        "bash": "sondera copilot subagent-start",
+        "powershell": "sondera.exe copilot subagent-start",
+        "timeoutSec": 30
+      }
+    ],
+    "subagentStop": [
+      {
+        "type": "command",
+        "bash": "sondera copilot subagent-stop",
+        "powershell": "sondera.exe copilot subagent-stop",
+        "timeoutSec": 30
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "sondera copilot user-prompt-submitted",
+        "powershell": "sondera.exe copilot user-prompt-submitted",
+        "timeoutSec": 30
+      }
+    ]
+  }
+}

--- a/examples/github_copilot_cli_hooks/README.md
+++ b/examples/github_copilot_cli_hooks/README.md
@@ -1,0 +1,112 @@
+# GitHub Copilot CLI Hook Enforcement Example
+
+This example shows the local GitHub Copilot CLI hook enforcement path using
+the `sondera` binary:
+
+```text
+Copilot CLI -> .github/hooks/sondera.json -> sondera copilot ... -> Sondera
+```
+
+The existing loose examples in this repository show policy snippets and event
+payloads. This directory is a runnable scenario: a hook config, fixture
+payloads, a demo Cedar policy pack, and a smoke script that sends Copilot hook
+events through `sondera copilot ...`.
+
+## Prerequisites
+
+```bash
+sondera auth login
+copilot auth login
+jq --version
+```
+
+Install the `sondera` CLI from your approved release channel. The example uses
+the umbrella `sondera copilot ...` commands; it does not require the older
+standalone `sondera-copilot` app binary in this repository.
+
+## Install
+
+From a repository where Copilot CLI should run hooks:
+
+```bash
+mkdir -p .github/hooks
+cp examples/github_copilot_cli_hooks/.github/hooks/sondera.json .github/hooks/sondera.json
+```
+
+Or generate a managed hook config from the CLI:
+
+```bash
+sondera copilot install
+```
+
+## Fixture Smoke
+
+Run the fixture payloads through the canonical commands:
+
+```bash
+sondera copilot session-start < fixtures/sessionStart.json
+sondera copilot user-prompt-submitted < fixtures/userPromptSubmitted.json
+sondera copilot pre-tool-use < fixtures/preToolUse-allow.json
+sondera copilot pre-tool-use < fixtures/preToolUse-deny.json
+sondera copilot pre-tool-use < fixtures/preToolUse-rewrite.json
+sondera copilot permission-request < fixtures/permissionRequest-rewrite.json
+sondera copilot post-tool-use-failure < fixtures/postToolUseFailure.json
+sondera copilot agent-stop < fixtures/agentStop.json
+sondera copilot session-end < fixtures/sessionEnd.json
+```
+
+For a repeatable local run, patch the fixtures to a fresh session/workdir and
+execute the same sequence:
+
+```bash
+SONDERA_BIN=sondera ./scripts/run_fixture_smoke.sh
+```
+
+By default, this proves local hook execution and command compatibility. To
+require policy-shaped responses, bind the policy pack below to the Copilot
+agent in govern mode and run:
+
+```bash
+EXPECT_POLICY_DECISIONS=1 ./scripts/run_fixture_smoke.sh
+```
+
+To additionally require a `modifiedArgs` rewrite response for the rewrite
+fixture, configure a policy binding that rewrites the risky command and run:
+
+```bash
+EXPECT_POLICY_DECISIONS=1 EXPECT_REWRITE=1 ./scripts/run_fixture_smoke.sh
+```
+
+## Policy Pack
+
+The `policies/` directory is a demo Cedar policy pack that can be bound through
+your configured Sondera policy workflow. The hook transport itself still runs
+through the local `sondera copilot ...` commands above.
+
+`policies/investment_cli_hooks.cedar` permits normal hook events and denies
+risky shell commands that try to delete files or expose investment identifiers.
+The rewrite fixture uses the same risky portfolio-report command shape that a
+governed policy binding can replace with bounded, read-only arguments through
+Copilot's `modifiedArgs` response.
+
+## Investment Scenario
+
+Use prompts and actions that mirror an investment-advisor agent:
+
+- Allowed: inspect a demo portfolio and run a read-only calculation.
+- Denied: expose account identifiers or run a destructive shell command.
+- Rewrite: replace a risky free-form portfolio report with a bounded read-only
+  command through `modifiedArgs`.
+- Permission request: exercise Copilot's separate permission service response
+  model, which uses `behavior` and `message` rather than `permissionDecision`.
+
+## Troubleshooting
+
+- If hooks do not run, check for `disableAllHooks` in repository or user
+  settings.
+- If an allowed `preToolUse` bypasses Copilot's native permission UI, verify
+  the response is `{}` and does not include an explicit `permissionDecision`.
+- If `permissionRequest` behaves like `preToolUse`, confirm the hook command is
+  `sondera copilot permission-request`, not `sondera copilot pre-tool-use`.
+- If the smoke exits before reaching a policy decision, verify that `sondera`
+  is authenticated and the selected policy profile is available.

--- a/examples/github_copilot_cli_hooks/fixtures/agentStop.json
+++ b/examples/github_copilot_cli_hooks/fixtures/agentStop.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": 1778700007000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "reason": "Copilot completed the investment portfolio review."
+}

--- a/examples/github_copilot_cli_hooks/fixtures/permissionRequest-rewrite.json
+++ b/examples/github_copilot_cli_hooks/fixtures/permissionRequest-rewrite.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": 1778700005000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "toolName": "bash",
+  "toolArgs": "{\"command\":\"python scripts/portfolio_report.py --customer CUST001 --include-account-number\"}",
+  "matcher": {
+    "toolName": "bash"
+  },
+  "reason": "Copilot is asking whether it may run a command that includes account identifiers."
+}

--- a/examples/github_copilot_cli_hooks/fixtures/postToolUseFailure.json
+++ b/examples/github_copilot_cli_hooks/fixtures/postToolUseFailure.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": 1778700006000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "toolName": "bash",
+  "toolArgs": {
+    "command": "python scripts/portfolio_report.py --customer CUST001 --include-account-number"
+  },
+  "toolError": {
+    "stderr": "policy denied access to account_number",
+    "exit_code": 2
+  },
+  "exitCode": 2
+}

--- a/examples/github_copilot_cli_hooks/fixtures/preToolUse-allow.json
+++ b/examples/github_copilot_cli_hooks/fixtures/preToolUse-allow.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": 1778700002000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "toolName": "bash",
+  "toolArgs": {
+    "command": "python scripts/portfolio_report.py --customer CUST001 --read-only"
+  },
+  "matcher": {
+    "toolName": "bash"
+  }
+}

--- a/examples/github_copilot_cli_hooks/fixtures/preToolUse-deny.json
+++ b/examples/github_copilot_cli_hooks/fixtures/preToolUse-deny.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": 1778700003000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "toolName": "bash",
+  "toolArgs": {
+    "command": "cat data/customers.csv | grep social_security_number"
+  },
+  "matcher": {
+    "toolName": "bash"
+  }
+}

--- a/examples/github_copilot_cli_hooks/fixtures/preToolUse-rewrite.json
+++ b/examples/github_copilot_cli_hooks/fixtures/preToolUse-rewrite.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": 1778700004000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "toolName": "bash",
+  "toolArgs": {
+    "command": "python scripts/portfolio_report.py --customer CUST001 --include-account-number"
+  },
+  "matcher": {
+    "toolName": "bash"
+  }
+}

--- a/examples/github_copilot_cli_hooks/fixtures/sessionEnd.json
+++ b/examples/github_copilot_cli_hooks/fixtures/sessionEnd.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": 1778700008000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "reason": "completed"
+}

--- a/examples/github_copilot_cli_hooks/fixtures/sessionStart.json
+++ b/examples/github_copilot_cli_hooks/fixtures/sessionStart.json
@@ -1,0 +1,7 @@
+{
+  "timestamp": 1778700000000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "source": "new",
+  "initialPrompt": "Review the demo portfolio for CUST001 using read-only commands."
+}

--- a/examples/github_copilot_cli_hooks/fixtures/userPromptSubmitted.json
+++ b/examples/github_copilot_cli_hooks/fixtures/userPromptSubmitted.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": 1778700001000,
+  "cwd": "/tmp/investment-agent-demo",
+  "sessionId": "investment-copilot-demo",
+  "prompt": "Show portfolio performance for CUST001 and do not expose account identifiers."
+}

--- a/examples/github_copilot_cli_hooks/policies/investment_cli_hooks.cedar
+++ b/examples/github_copilot_cli_hooks/policies/investment_cli_hooks.cedar
@@ -1,0 +1,23 @@
+// Minimal investment-advisor hook policy for the Copilot CLI example.
+//
+// The runnable hook path uses local `sondera copilot ...` commands. This policy
+// mirrors a small investment workflow: normal hook events are allowed, but
+// destructive shell commands and sensitive account identifier exposure are
+// denied in govern mode.
+
+@id("investment-cli-hooks-default-permit")
+@description("Permit normal Copilot CLI hook events unless a specific investment safety guard fires.")
+permit(principal, action, resource);
+
+@id("investment-cli-hooks-forbid-risky-shell")
+@description("Block destructive commands and attempts to expose sensitive investment identifiers.")
+forbid(
+    principal,
+    action == Action::"ShellCommand",
+    resource
+) when {
+    context.command like "*rm -rf*" ||
+    context.command like "*account_number*" ||
+    context.command like "*social_security_number*" ||
+    context.command like "*ssn*"
+};

--- a/examples/github_copilot_cli_hooks/policies/spec.toml
+++ b/examples/github_copilot_cli_hooks/policies/spec.toml
@@ -1,0 +1,7 @@
+id = "investment-copilot-cli-hooks"
+hierarchy = "principal"
+
+[metadata]
+display_name = "Investment Copilot CLI Hooks"
+description = "Govern-mode policy pack for the GitHub Copilot CLI hook investment example."
+category = "example"

--- a/examples/github_copilot_cli_hooks/scripts/run_fixture_smoke.sh
+++ b/examples/github_copilot_cli_hooks/scripts/run_fixture_smoke.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+example_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+sondera_bin="${SONDERA_BIN:-sondera}"
+expect_policy_decisions="${EXPECT_POLICY_DECISIONS:-0}"
+expect_rewrite="${EXPECT_REWRITE:-0}"
+last_stdout_file=""
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to patch and validate fixture payloads" >&2
+  exit 1
+fi
+
+if ! command -v "$sondera_bin" >/dev/null 2>&1 && [ ! -x "$sondera_bin" ]; then
+  echo "SONDERA_BIN is not executable or on PATH: $sondera_bin" >&2
+  exit 1
+fi
+
+run_id="investment-copilot-demo-$(date +%Y%m%d%H%M%S)-$$"
+run_dir="$(mktemp -d "${TMPDIR:-/tmp}/sondera-copilot-investment.XXXXXX")"
+mkdir -p "$run_dir/.github/hooks" "$run_dir/data" "$run_dir/scripts" "$run_dir/fixtures"
+
+cp "$example_dir/.github/hooks/sondera.json" "$run_dir/.github/hooks/sondera.json"
+
+cat >"$run_dir/data/portfolio.csv" <<'CSV'
+ticker,quantity,price
+VOO,12,478.20
+BND,18,72.12
+VXUS,7,62.44
+CSV
+
+cat >"$run_dir/data/customers.csv" <<'CSV'
+customer_id,name,account_number,social_security_number
+CUST001,Avery Example,ACCT-0001,000-00-0001
+CSV
+
+cat >"$run_dir/scripts/portfolio_report.py" <<'PY'
+import argparse
+import csv
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--customer", required=True)
+parser.add_argument("--read-only", action="store_true")
+parser.add_argument("--include-account-number", action="store_true")
+args = parser.parse_args()
+
+rows = list(csv.DictReader(Path("data/portfolio.csv").open()))
+total = sum(float(row["quantity"]) * float(row["price"]) for row in rows)
+print(f"demo portfolio value for {args.customer}: ${total:,.2f}")
+
+if args.include_account_number:
+    customer = next(csv.DictReader(Path("data/customers.csv").open()))
+    print(f"account_number={customer['account_number']}")
+PY
+
+for fixture in "$example_dir"/fixtures/*.json; do
+  jq --arg sid "$run_id" --arg cwd "$run_dir" \
+    '.sessionId=$sid | .cwd=$cwd' \
+    "$fixture" >"$run_dir/fixtures/$(basename "$fixture")"
+done
+
+run_hook() {
+  local subcommand="$1"
+  local fixture="$2"
+  local stdout_file="$run_dir/${subcommand//-/_}.${fixture%.json}.stdout"
+  local stderr_file="$run_dir/${subcommand//-/_}.${fixture%.json}.stderr"
+
+  echo
+  echo "==> sondera copilot $subcommand < $fixture"
+  if "$sondera_bin" copilot "$subcommand" <"$run_dir/fixtures/$fixture" >"$stdout_file" 2>"$stderr_file"; then
+    echo "exit: 0"
+  else
+    local status=$?
+    echo "exit: $status"
+    if [ -s "$stderr_file" ]; then
+      sed 's/^/stderr: /' "$stderr_file" >&2
+    fi
+    echo "run dir: $run_dir" >&2
+    exit "$status"
+  fi
+
+  if [ -s "$stdout_file" ]; then
+    sed 's/^/stdout: /' "$stdout_file"
+  else
+    echo "stdout: <empty>"
+  fi
+
+  last_stdout_file="$stdout_file"
+}
+
+assert_json() {
+  local file="$1"
+  local filter="$2"
+  local message="$3"
+
+  if ! awk '/^[[:space:]]*\{/ { payload=$0 } END { if (payload == "") exit 1; print payload }' "$file" | jq -e "$filter" >/dev/null; then
+    echo "assertion failed: $message" >&2
+    echo "stdout was:" >&2
+    sed 's/^/  /' "$file" >&2
+    echo "run dir: $run_dir" >&2
+    exit 1
+  fi
+}
+
+echo "run dir: $run_dir"
+echo "session: $run_id"
+echo "binary: $sondera_bin"
+
+run_hook session-start sessionStart.json
+run_hook user-prompt-submitted userPromptSubmitted.json
+run_hook pre-tool-use preToolUse-allow.json
+allow_stdout="$last_stdout_file"
+run_hook pre-tool-use preToolUse-deny.json
+deny_stdout="$last_stdout_file"
+run_hook pre-tool-use preToolUse-rewrite.json
+rewrite_stdout="$last_stdout_file"
+run_hook permission-request permissionRequest-rewrite.json
+permission_stdout="$last_stdout_file"
+run_hook post-tool-use-failure postToolUseFailure.json
+failure_stdout="$last_stdout_file"
+run_hook agent-stop agentStop.json
+run_hook session-end sessionEnd.json
+
+if [ "$expect_policy_decisions" = "1" ]; then
+  assert_json "$allow_stdout" '. == {}' "allowed preToolUse should fall through as {}"
+  assert_json "$deny_stdout" '.permissionDecision == "deny"' "risky preToolUse should deny"
+  assert_json "$permission_stdout" '.behavior == "deny" or .behavior == "allow"' \
+    "permissionRequest should use the behavior/message response model"
+  assert_json "$failure_stdout" '.additionalContext or .decision' \
+    "postToolUseFailure should return additional context or a continuation decision"
+fi
+
+if [ "$expect_rewrite" = "1" ]; then
+  assert_json "$rewrite_stdout" '.permissionDecision == "allow" and (.modifiedArgs | type == "object")' \
+    "rewrite fixture should return an object-valued modifiedArgs response"
+fi
+
+echo
+echo "Smoke complete. Policy decisions reflect the active Sondera policy profile for the Copilot agent."


### PR DESCRIPTION
## Summary

- Add a runnable GitHub Copilot CLI example under examples/github_copilot_cli_hooks.
- Include a .github/hooks/sondera.json config that uses the sondera copilot command surface.
- Add investment-advisor fixtures, a sample Cedar policy pack, and a smoke script with optional strict policy-response checks.
- Link the example from the root README.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-features -- -D warnings
- cargo test --workspace
- cargo deny check
- cargo audit --deny warnings --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0134
- find examples/github_copilot_cli_hooks -name '*.json' -print0 | xargs -0 -n1 jq empty
- bash -n examples/github_copilot_cli_hooks/scripts/run_fixture_smoke.sh
- cedar check-parse --policies examples/github_copilot_cli_hooks/policies/investment_cli_hooks.cedar --schema policies/base.cedarschema --schema-format cedar
- cedar validate --schema policies/base.cedarschema --schema-format cedar --policies examples/github_copilot_cli_hooks/policies/investment_cli_hooks.cedar
- git diff --check origin/main...HEAD
- Public-boundary scan over the PR diff