### PR TITLE
chore(security): refresh audit baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: cargo deny check
 
       - name: Audit
-        run: cargo audit --deny warnings --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2026-0006 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0134
+        run: cargo audit --deny warnings --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0134
 
 
   build-apps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4575,12 +4575,12 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "munge",
  "ptr_meta",
@@ -4593,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5702,7 +5702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.59.0",

--- a/deny.toml
+++ b/deny.toml
@@ -17,14 +17,9 @@ allow = [
     "MIT-0",
     "MPL-2.0",
     "Unicode-3.0",
-    "OpenSSL",
     "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.8
-
-[[licenses.exceptions]]
-allow = ["bzip2-1.0.6"]
-name = "libbz2-rs-sys"
 
 [licenses.private]
 ignore = true
@@ -41,8 +36,6 @@ ignore = [
     "RUSTSEC-2023-0071",
     # Transitive via turbomcp-transport -> rustls-pemfile (unmaintained, no fix available)
     "RUSTSEC-2025-0134",
-    # Transitive dependency advisory (no fix available)
-    "RUSTSEC-2026-0006",
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

- Update the audited transitive dependency to the patched release.
- Remove stale audit and license allowlist entries that no longer match the dependency graph.
- Keep the CI audit ignore list aligned with the local security policy.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo deny check`
- `cargo audit --deny warnings --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0134`
- `git diff --check`
- Public-boundary scan over the diff
