### PR TITLE
chore: bump openssl to 0.10.80

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,15 +3658,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3690,9 +3689,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary
- Bumps transitive dependency `openssl` from `0.10.75` → `0.10.80`
- Bumps `openssl-sys` from `0.9.111` → `0.9.116`

Remediates 5 high-severity CVEs:
| CVE | Affected range |
|-----|---------------|
| CVE-2026-41678 | openssl >= 0.10.24, < 0.10.78 |
| CVE-2026-41681 | openssl >= 0.10.39, < 0.10.78 |
| CVE-2026-41898 | openssl >= 0.9.24, < 0.10.78 |
| CVE-2026-41676 | openssl >= 0.9.27, < 0.10.78 |
| CVE-2026-42327 | openssl >= 0.9.7, < 0.10.79 |