### PR TITLE
Ignore irrelevant `wasmtime` security advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -36,6 +36,9 @@ ignore = [
     # engine here, which the advisory identifies as unaffected; no compatible
     # patched Wasmtime release exists in YARA-X's current dependency range.
     "RUSTSEC-2026-0222",
+    # Transitive via yara-x -> wasmtime. The vulnerable filesystem implementation
+    # is in wasmtime-wasi, which is not present in the resolved dependency graph.
+    "RUSTSEC-2026-0269",
 ]
 
 [sources]


### PR DESCRIPTION
Ignore `RUSTSEC-2026-0269` in `cargo-deny`

YARA-X depends on `wasmtime` with default features disabled and only the runtime and Cranelift features enabled. The upstream advisory describes a sandbox escape in the separate `wasmtime-wasi` filesystem implementation through `cap-std`; neither `wasmtime-wasi` nor the affected `cap-std` implementation is present in this workspace dependency graph.

This exception should be removed once YARA-X moves to a `wasmtime` release outside the advisory range.

Upstream advisory: https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg